### PR TITLE
Recovery audit of f85798c: fix wall-limit mislabel and lock-fd truncation

### DIFF
--- a/AUDIT_RECOVERY_20260811.md
+++ b/AUDIT_RECOVERY_20260811.md
@@ -11,15 +11,33 @@ Files audited: `src/migrate_legacy_exact_pool.py`, `src/durable_io.py`,
 `src/campaign_artifact_status.py`, the three recovery test modules, and the
 `f4e31c3` versions of the pricer, config, and campaign submit file.
 
+**Evidence basis.** Every dynamic claim in this report was obtained on a
+local audit VM (single node, local filesystem, Python 3.12.3) using synthetic
+fixture artifacts and committed sample instances, plus source-code reading of
+the pinned commits. None of it inspected the actual damaged task-22/24/32
+artifacts, the Unicorn filesystems, or Unicorn's Slurm configuration; those
+remain open verification items (section 3). "Verified" below therefore means
+"verified locally against synthetic fixtures and the committed code", never
+"verified on the cluster".
+
 ## 1. Confirmed correctness
 
-- **Model semantics are unchanged.** `git diff f4e31c3 f85798c` touches no
-  routing, charging, tariff, battery, or objective code:
-  `audit_giro_known_columns.py`, `utils_v2.py`, `config.py`, and
-  `pricing_dp_og.py` are byte-identical to the legacy commit. Only
-  `master_lp_scipy.py` changed (LP result hygiene + the deliberate,
-  pre-existing 1e-7 -> 1e-6 tolerance from 2cc40d9/47a9a49). HiGHS remains
-  the CG master; nothing switches to Gurobi.
+- **The recovery commit changes no model semantics, and the expanded-network
+  pricing model is unchanged across the whole range.** Two precise claims,
+  narrower than an earlier draft of this report: (a) `f85798c` versus its
+  direct parent `47a9a49` touches only recovery/durability/launcher code,
+  tests, and the runbook — no solver, network, or cost logic; (b) the
+  expanded-network pricing model specifically — the `ExpandedNetwork`
+  node/arc/cost construction and pricing pass, the singleton seeder, and its
+  inputs `audit_giro_known_columns.py`, `utils_v2.py`, `config.py`,
+  `pricing_dp_og.py` — is byte-identical from `f4e31c3` through `f85798c`;
+  the pricer diffs in that range are confined to resume/journal/status
+  handling. The broader range did change other model-adjacent code outside
+  the exact-pricer path: `rerealize_routes.py` (8227034, zero-length
+  wait-window fix), `master_lp_scipy.py` (2cc40d9/47a9a49, LP hygiene and
+  the deliberate 1e-7 -> 1e-6 tolerance), and `run_exact_pool_mip.py` /
+  `run_matchmip_escalate.py` (47a9a49, MIP side). HiGHS remains the CG
+  master; nothing switches to Gurobi.
 - **The legacy failure mechanism is what the runbook claims.** The `f4e31c3`
   resume loop does `json.loads(line)` per journal line with no repair, and it
   crashes *before* opening the journal in append mode, so the damaged
@@ -32,40 +50,47 @@ Files audited: `src/migrate_legacy_exact_pool.py`, `src/durable_io.py`,
   built for. Legacy snapshots cannot self-witness (no
   `snapshot_mark_minutes`, no provenance), and the damaged statuses
   themselves are excluded (`stop_reason="running"` is not a stable witness).
-- **Fail-closed behavior verified end-to-end** (real CLI, no mocks): missing
+- **Fail-closed behavior verified end-to-end** (real CLI, no mocks, on
+  synthetic fixture artifacts — not the Unicorn originals): missing
   witness exits 2 with the `no authenticated .* witness` message the `.sub`
   classifies as WAIT; conflicting witnesses exit 2 with a message that does
   *not* match the WAIT pattern (fatal, as intended); interior journal
   corruption refuses without touching any source byte; sources are hashed
   before and after both preview and copy, so concurrent modification of the
   legacy artifacts aborts the migration.
-- **Copy-only isolation verified.** After `--apply`, the legacy status,
-  journal, iters, and log bytes are unchanged; the raw archive under
-  `*.legacy_raw/` is byte-identical to the sources on a distinct inode; the
-  repaired tail bytes are quarantined (`*_changed_tail.bin`); repairs happen
-  only on staged working copies.
-- **Idempotency and preemption-mid-append verified.** Re-running `--apply`
-  after (a) success, (b) the continuation extending the journal, and (c) a
+- **Copy-only isolation verified** (synthetic fixtures). After `--apply`,
+  the legacy status, journal, iters, and log bytes are unchanged; the raw
+  archive under `*.legacy_raw/` is byte-identical to the sources on a
+  distinct inode; the repaired tail bytes are quarantined
+  (`*_changed_tail.bin`); repairs happen only on staged working copies.
+- **Idempotency and preemption-mid-append verified** (synthetic fixtures).
+  Re-running `--apply` after (a) success, (b) the continuation extending the
+  journal, and (c) a
   simulated preemption that truncated the final appended record all validate
   the migrated prefix hashes and return "already prepared" without writing.
   The pricer's narrow tail repair truncates exactly back to the last complete
   record, which can never reach inside the migrated prefix (the prefix ends
   on a complete, newline-terminated record by construction).
-- **Publication ordering is crash-safe.** The migration writes raw archive ->
-  journal -> iters -> attestation -> status (commit marker) with fsynced
-  atomic renames; the pricer publishes identity (`initializing` /
-  `resume_starting`) before opening append handles; journal appends are
-  fsynced before the status that counts them; immutable snapshots publish the
-  journal copy before the discoverable status JSON, and the orphan-recovery
-  path re-publishes an interrupted snapshot status only from a prior status
-  with the matching `snapshot_mN` stop reason, column count, and positive
-  routes.
-- **Locking verified across processes.** `exclusive_output_lock` refuses a
-  concurrent second owner (with owner diagnostics in the message), and a
-  requeue acquires the lock after the previous owner is SIGKILLed. A live
-  kill-and-resume run on the committed TwoDuty instance resumed the pool,
-  kept `iters.csv` elapsed monotone across attempts, refused a rerun without
-  `--resume`, and refused a concurrent duplicate.
+- **Publication ordering is SIGKILL/process-preemption-safe.** The migration
+  writes raw archive -> journal -> iters -> attestation -> status (commit
+  marker) with fsynced atomic renames; the pricer publishes identity
+  (`initializing` / `resume_starting`) before opening append handles; journal
+  appends are fsynced before the status that counts them; immutable snapshots
+  publish the journal copy before the discoverable status JSON, and the
+  orphan-recovery path re-publishes an interrupted snapshot status only from
+  a prior status with the matching `snapshot_mN` stop reason, column count,
+  and positive routes. This claim covers process death at any instruction
+  (Slurm preemption's SIGTERM/SIGKILL); it does not extend to node power
+  loss or to rename/fsync semantics of the cluster filesystem, which were
+  not tested here.
+- **Locking verified across processes on a single node** (local filesystem).
+  `exclusive_output_lock` refuses a concurrent second owner (with owner
+  diagnostics in the message), and a requeue acquires the lock after the
+  previous owner is SIGKILLed. A live kill-and-resume run on the committed
+  TwoDuty instance resumed the pool, kept `iters.csv` elapsed monotone across
+  attempts, refused a rerun without `--resume`, and refused a concurrent
+  duplicate. Cross-node lock visibility on Unicorn's shared filesystem is
+  explicitly NOT covered by this evidence (section 3).
 - **Resume identity checks fire before any artifact is modified**, including
   the git-commit discipline: a legacy status resumed directly (bypassing
   migration) is refused for missing provenance hashes and/or commit mismatch
@@ -86,20 +111,26 @@ Files audited: `src/migrate_legacy_exact_pool.py`, `src/durable_io.py`,
 
 ## 2. Bugs fixed on this branch (`cursor/recovery-audit`)
 
-1. **Wall-limit expiry mid-master was mislabeled `master_failed`**
-   (`src/exact_pricer_expanded.py`). If the cumulative wall budget ran out
-   *between* master method attempts (the in-loop `_remaining_wall_s(30) <= 0`
-   break), `lp` stayed `None` and the run recorded
-   `stop_reason="master_failed"` even when the wall — not the solver — ended
-   the run (in the worst case without attempting any method that iteration).
-   That violates the honest-labeling rule and misclassifies a resumable timed
-   stop as a solver failure. Not reachable by the recovery jobs (they set no
-   `--wall-limit-s`) but reachable by every wall-limited campaign sharing
-   `run_cg`, e.g. the snapshot-control continuations, where `master_failed`
-   vs `wall_limit` changes `control_result_complete`. Fixed to label the stop
-   `wall_limit`; genuine three-method failures keep `master_failed`.
-   Regression tests: `test_wall_expiry_between_master_attempts_is_labeled_wall_limit`
-   (fails against f85798c, passes with the fix) and
+1. **Wall-limit expiry inside the master method loop was mislabeled
+   `master_failed`** (`src/exact_pricer_expanded.py`). If the cumulative wall
+   budget ran out while cycling master methods, `lp` stayed `None` and the
+   run recorded `stop_reason="master_failed"` even when the wall — not the
+   solver — ended the run. That violates the honest-labeling rule and
+   misclassifies a resumable timed stop as a solver failure. Not reachable by
+   the recovery jobs (they set no `--wall-limit-s`) but reachable by every
+   wall-limited campaign sharing `run_cg`, e.g. the snapshot-control
+   continuations, where `master_failed` vs `wall_limit` changes
+   `control_result_complete`. The fix evaluates wall exhaustion at the
+   `lp is None` exit path itself, so it also covers the boundary where the
+   third and *final* method attempt consumes the remaining budget and then
+   raises — a case a mid-loop check alone cannot see, because no later loop
+   iteration runs (found in external review of the first version of this
+   fix). Genuine all-method failures with budget remaining keep
+   `master_failed`. Regression tests:
+   `test_wall_expiry_between_master_attempts_is_labeled_wall_limit`,
+   `test_wall_expiry_during_final_master_attempt_is_labeled_wall_limit`
+   (wall_limit_s=200, three 60 s failing attempts; fails against both f85798c
+   and the first flag-based fix), and
    `test_exhausting_all_master_methods_stays_labeled_master_failed`.
 2. **The `.sub` truncated the flock diagnostic record before losing the
    race** (`src/submit_legacy_bigtariff_recovery.sub`). `exec 9>` opens with
@@ -108,6 +139,19 @@ Files audited: `src/migrate_legacy_exact_pool.py`, `src/durable_io.py`,
    the `flock -n` and exited. Kernel locking was never at risk; only the
    diagnostics that explain a SKIP_LOCKED. Fixed to `exec 9>>` (append).
    Guarded by `test_job_lock_fd_uses_append_mode`.
+3. **The conda fallback loop stopped on the first *activatable* environment,
+   not the first Python 3.12 one** (`src/submit_legacy_bigtariff_recovery.sub`).
+   If `/home/nc437/evsp_env` activates but is still a 3.10 environment, the
+   loop broke there and the subsequent 3.12 assertion fataled the whole job
+   without ever trying `evsp_env312` or the later candidates. The loop now
+   verifies `sys.version_info[:2] == (3, 12)` inside the loop and keeps
+   searching past non-3.12 candidates; the post-loop assertion remains as a
+   final guard. Covered by two tests that execute the script's actual
+   selection block under mocked `conda`/`python`:
+   `test_conda_fallback_skips_activatable_non_python312_environment` and
+   `test_conda_fallback_selects_nothing_without_a_python312_candidate` (both
+   fail against the previous loop). The same fallback pattern exists in the
+   other campaign `.sub` files; fixing those is out of scope for this branch.
 
 Also added `tests/test_legacy_recovery_scripts.py`: the launcher and `.sub`
 previously had zero test coverage. It now pins bash parseability, the
@@ -118,15 +162,16 @@ against the original array arithmetic, and the dual commit pinning.
 
 ## 3. Operational risks needing Unicorn verification (not code changes)
 
-1. **flock semantics on the results filesystem.** Both `flock(1)` in the
-   `.sub` and `fcntl.flock` in `durable_io` assume real cross-node locking.
-   On NFSv4 this holds; on Lustre mounted with `localflock` (or `noflock`)
-   two jobs on different nodes could both "acquire" the lock. One-time check
-   before `--submit`: run the `.sub`'s flock line from two different nodes
-   against a scratch file under the same filesystem as
-   `src/results/`, or check `mount | grep -E 'flock|nfs'`. The runbook's
-   single-launcher discipline plus semantic job-name dedup makes collisions
-   unlikely regardless.
+1. **Cross-node flock semantics on the results filesystem — UNVERIFIED.**
+   All locking evidence in this audit is single-node on a local filesystem.
+   Both `flock(1)` in the `.sub` and `fcntl.flock` in `durable_io` assume
+   real cross-node locking. On NFSv4 this holds; on Lustre mounted with
+   `localflock` (or `noflock`) two jobs on different nodes could both
+   "acquire" the lock. One-time check before `--submit`: run the `.sub`'s
+   flock line from two different nodes against a scratch file under the same
+   filesystem as `src/results/`, or check `mount | grep -E 'flock|nfs'`. The
+   runbook's single-launcher discipline plus semantic job-name dedup makes
+   collisions unlikely regardless.
 2. **Witness availability.** Tasks 22/32 need a hashed *terminal* k30_r2
    status and a peak18/sek prices witness in `~/EVSP-DR/src/results`; task 24
    needs k30_r4. Which of the 8 completed 867334 cells (or older terminal
@@ -145,14 +190,21 @@ against the original array arithmetic, and the dual commit pinning.
    requires a human to preserve the orphans and pick a new output path. This
    is by design (fail-closed provenance) — just be aware the recovery is
    self-healing for pricer preemption, not for migration preemption.
-5. **Python 3.12 conda fallback order.** The `.sub` activates the first env
-   that exists and *then* asserts 3.12; if `/home/nc437/evsp_env` is still a
-   3.10 env the job fatals immediately. The runbook already treats the first
-   submissions as the real 3.12 check against the damaged tails.
-6. **Real damaged-tail classes.** Local tests cover truncated JSON,
-   concatenated-then-truncated records, non-UTF8, and non-object tails; the
-   actual task-22/24/32 bytes are only on Unicorn. A refusal there is
-   evidence to preserve, per the runbook.
+5. **Actual Unicorn conda environments.** The fallback loop now skips
+   non-3.12 candidates (section 2, fix 3), but which environments exist and
+   activate on Unicorn, and whether any provides Python 3.12 with the pinned
+   dependencies, is only knowable on the cluster.
+6. **The real damaged task-22/24/32 artifacts — NEVER INSPECTED here.**
+   Local tests cover truncated JSON, concatenated-then-truncated records,
+   non-UTF8, and non-object tails, all on synthetic fixtures; the actual
+   damaged bytes exist only on Unicorn. The first real submissions are the
+   genuine test of the repair against those tails (the runbook says the
+   same), and a refusal there is evidence to preserve, not bypass. No
+   Unicorn recovery success is claimed anywhere in this report.
+7. **Filesystem durability semantics.** fsync-before-rename and atomic
+   `os.replace` behavior were exercised on a local ext4 filesystem only;
+   NFS/Lustre rename and fsync visibility after a node crash were not
+   tested.
 
 ## 4. Optional suggestions (do not block the recovery launch)
 
@@ -180,7 +232,9 @@ against the original array arithmetic, and the dual commit pinning.
 
 Environment: Python 3.12.3, `numpy==2.2.6 pandas==2.3.3 scipy==1.15.3
 matplotlib==3.10.9` (pinned per `requirements-unicorn.txt`), pytest 9.x,
-Linux; repository clean at each run.
+Linux, single node, local ext4 filesystem; repository clean at each run.
+All artifacts below are synthetic fixtures or committed sample instances —
+none are the real Unicorn artifacts.
 
 1. `cd tests && python3 -m pytest -q` at `f85798c` (pre-change baseline):
    **204 passed, 23 subtests passed** in 20.2s.
@@ -191,17 +245,30 @@ Linux; repository clean at each run.
    preemption mid-append plus pricer-style repair; missing witness exits 2
    matching the WAIT grep; conflicting witnesses exit 2 NOT matching the WAIT
    grep. **All passed.**
-3. Cross-process lock script: contention refused with owner diagnostics;
-   SIGKILL of the holder releases the lock for a requeue. **Passed.**
+3. Cross-process (single-node) lock script: contention refused with owner
+   diagnostics; SIGKILL of the holder releases the lock for a requeue.
+   **Passed.**
 4. Live preemption simulation on `Practice_Custom_TwoDuty_13301_13302.csv`:
    fresh run SIGKILLed mid-CG (journal 433 columns), `--resume` completed
    (417 iterations, 7,813 columns, `final_lp_source=final_pool_resolve`),
    `iters.csv` elapsed monotone across attempts, rerun without `--resume`
    refused, concurrent duplicate refused by the output lock. **Passed.**
-5. `bash -n` and `shellcheck -S warning` on both recovery scripts: **clean**.
-6. Regression validity: `test_wall_expiry_between_master_attempts_is_labeled_wall_limit`
+5. `bash -n` and `shellcheck -S warning` on both recovery scripts: **clean**
+   (re-run after every script change).
+6. Regression validity, first pass:
+   `test_wall_expiry_between_master_attempts_is_labeled_wall_limit`
    **fails against unmodified f85798c** (observed `master_failed`) and passes
    with fix 1.
-7. `cd tests && python3 -m pytest -q` after the fixes on
-   `cursor/recovery-audit`: **213 passed, 28 subtests passed** in 20.7s
+7. `cd tests && python3 -m pytest -q` after the first pass:
+   **213 passed, 28 subtests passed** in 20.7s
    (baseline 204 + 2 wall-limit labeling tests + 7 recovery-script tests).
+8. Correction pass regression validity:
+   `test_wall_expiry_during_final_master_attempt_is_labeled_wall_limit`
+   (wall_limit_s=200, three 60 s failing attempts) **fails against the
+   first flag-based fix** (observed `master_failed`) and passes with the
+   exit-path evaluation; both conda-fallback tests **fail against the
+   previous selection loop** (it selected the activatable 3.10 environment)
+   and pass with the version-checked loop.
+9. `cd tests && python3 -m pytest -q` after the correction pass:
+   **216 passed, 28 subtests passed** (213 + 1 boundary wall-limit test
+   + 2 conda-fallback tests).

--- a/AUDIT_RECOVERY_20260811.md
+++ b/AUDIT_RECOVERY_20260811.md
@@ -1,0 +1,207 @@
+# Independent audit of commit f85798c ("Harden exact CG preemption recovery")
+
+Date: 2026-08-11. Auditor: independent review requested before launching the
+task-22/24/32 recovery on Unicorn. Scope: correctness, race conditions,
+provenance gaps, preemption behavior, Slurm requeue behavior, and unnecessary
+complexity of `f85798cbf172ddb463f083636abcf139d066d1df` on `peel-and-price`.
+
+Files audited: `src/migrate_legacy_exact_pool.py`, `src/durable_io.py`,
+`src/exact_pricer_expanded.py`, `src/launch_legacy_bigtariff_recovery.sh`,
+`src/submit_legacy_bigtariff_recovery.sub`, `src/run_cg_snapshot_control.py`,
+`src/campaign_artifact_status.py`, the three recovery test modules, and the
+`f4e31c3` versions of the pricer, config, and campaign submit file.
+
+## 1. Confirmed correctness
+
+- **Model semantics are unchanged.** `git diff f4e31c3 f85798c` touches no
+  routing, charging, tariff, battery, or objective code:
+  `audit_giro_known_columns.py`, `utils_v2.py`, `config.py`, and
+  `pricing_dp_og.py` are byte-identical to the legacy commit. Only
+  `master_lp_scipy.py` changed (LP result hygiene + the deliberate,
+  pre-existing 1e-7 -> 1e-6 tolerance from 2cc40d9/47a9a49). HiGHS remains
+  the CG master; nothing switches to Gurobi.
+- **The legacy failure mechanism is what the runbook claims.** The `f4e31c3`
+  resume loop does `json.loads(line)` per journal line with no repair, and it
+  crashes *before* opening the journal in append mode, so the damaged
+  journals were never modified after the crash.
+- **The witness design is sound against the real legacy artifacts.** The
+  `f4e31c3` *terminal* result writer stores `provenance.instance_sha256` /
+  `prices_sha256` plus every model field the migration checks
+  (`MODEL_FIELDS`), while its *periodic* partials store the model fields but
+  no provenance — exactly the gap the split-status witness reconstruction is
+  built for. Legacy snapshots cannot self-witness (no
+  `snapshot_mark_minutes`, no provenance), and the damaged statuses
+  themselves are excluded (`stop_reason="running"` is not a stable witness).
+- **Fail-closed behavior verified end-to-end** (real CLI, no mocks): missing
+  witness exits 2 with the `no authenticated .* witness` message the `.sub`
+  classifies as WAIT; conflicting witnesses exit 2 with a message that does
+  *not* match the WAIT pattern (fatal, as intended); interior journal
+  corruption refuses without touching any source byte; sources are hashed
+  before and after both preview and copy, so concurrent modification of the
+  legacy artifacts aborts the migration.
+- **Copy-only isolation verified.** After `--apply`, the legacy status,
+  journal, iters, and log bytes are unchanged; the raw archive under
+  `*.legacy_raw/` is byte-identical to the sources on a distinct inode; the
+  repaired tail bytes are quarantined (`*_changed_tail.bin`); repairs happen
+  only on staged working copies.
+- **Idempotency and preemption-mid-append verified.** Re-running `--apply`
+  after (a) success, (b) the continuation extending the journal, and (c) a
+  simulated preemption that truncated the final appended record all validate
+  the migrated prefix hashes and return "already prepared" without writing.
+  The pricer's narrow tail repair truncates exactly back to the last complete
+  record, which can never reach inside the migrated prefix (the prefix ends
+  on a complete, newline-terminated record by construction).
+- **Publication ordering is crash-safe.** The migration writes raw archive ->
+  journal -> iters -> attestation -> status (commit marker) with fsynced
+  atomic renames; the pricer publishes identity (`initializing` /
+  `resume_starting`) before opening append handles; journal appends are
+  fsynced before the status that counts them; immutable snapshots publish the
+  journal copy before the discoverable status JSON, and the orphan-recovery
+  path re-publishes an interrupted snapshot status only from a prior status
+  with the matching `snapshot_mN` stop reason, column count, and positive
+  routes.
+- **Locking verified across processes.** `exclusive_output_lock` refuses a
+  concurrent second owner (with owner diagnostics in the message), and a
+  requeue acquires the lock after the previous owner is SIGKILLed. A live
+  kill-and-resume run on the committed TwoDuty instance resumed the pool,
+  kept `iters.csv` elapsed monotone across attempts, refused a rerun without
+  `--resume`, and refused a concurrent duplicate.
+- **Resume identity checks fire before any artifact is modified**, including
+  the git-commit discipline: a legacy status resumed directly (bypassing
+  migration) is refused for missing provenance hashes and/or commit mismatch
+  before any repair side effect; an attested legacy migration additionally
+  hard-requires commit identity on both sides.
+- **Requeue behavior:** `--requeue`, `--open-mode=append`, explicit
+  `-t 7-00:00:00`, and re-verification of both checkout commits on every
+  (re)start; a requeued allocation re-runs the idempotent migration, skips
+  terminal results via `campaign_artifact_status --require-terminal`, and
+  resumes the pricer. Exit-0 WAIT (no witness) and SKIP states cannot loop.
+- **Original array mapping is correct.** Tasks 22/24/32 map to
+  k30_r2/peak18, k30_r4/peak18, k30_r2/sek under the original
+  `submit_cg_bigtariffs.sub` arithmetic, and the recovery `.sub` reproduces
+  the legacy campaign's identity-checked parameters (soc-step 15,
+  block-min 10, partition master, 300/300/0 defaults).
+- Full test suite at f85798c: **204 passed, 23 subtests passed** (Python
+  3.12.3, pinned requirements).
+
+## 2. Bugs fixed on this branch (`cursor/recovery-audit`)
+
+1. **Wall-limit expiry mid-master was mislabeled `master_failed`**
+   (`src/exact_pricer_expanded.py`). If the cumulative wall budget ran out
+   *between* master method attempts (the in-loop `_remaining_wall_s(30) <= 0`
+   break), `lp` stayed `None` and the run recorded
+   `stop_reason="master_failed"` even when the wall — not the solver — ended
+   the run (in the worst case without attempting any method that iteration).
+   That violates the honest-labeling rule and misclassifies a resumable timed
+   stop as a solver failure. Not reachable by the recovery jobs (they set no
+   `--wall-limit-s`) but reachable by every wall-limited campaign sharing
+   `run_cg`, e.g. the snapshot-control continuations, where `master_failed`
+   vs `wall_limit` changes `control_result_complete`. Fixed to label the stop
+   `wall_limit`; genuine three-method failures keep `master_failed`.
+   Regression tests: `test_wall_expiry_between_master_attempts_is_labeled_wall_limit`
+   (fails against f85798c, passes with the fix) and
+   `test_exhausting_all_master_methods_stays_labeled_master_failed`.
+2. **The `.sub` truncated the flock diagnostic record before losing the
+   race** (`src/submit_legacy_bigtariff_recovery.sub`). `exec 9>` opens with
+   O_TRUNC, so a duplicate submission erased the current owner's
+   `job=... host=... restart=...` line even though it then correctly failed
+   the `flock -n` and exited. Kernel locking was never at risk; only the
+   diagnostics that explain a SKIP_LOCKED. Fixed to `exec 9>>` (append).
+   Guarded by `test_job_lock_fd_uses_append_mode`.
+
+Also added `tests/test_legacy_recovery_scripts.py`: the launcher and `.sub`
+previously had zero test coverage. It now pins bash parseability, the
+requeue/time-limit/partition flags, append-mode locking, the legacy identity
+parameters, the WAIT-grep classification against the real `MigrationError`
+messages (missing witness matches; conflict must not), the task->cell mapping
+against the original array arithmetic, and the dual commit pinning.
+
+## 3. Operational risks needing Unicorn verification (not code changes)
+
+1. **flock semantics on the results filesystem.** Both `flock(1)` in the
+   `.sub` and `fcntl.flock` in `durable_io` assume real cross-node locking.
+   On NFSv4 this holds; on Lustre mounted with `localflock` (or `noflock`)
+   two jobs on different nodes could both "acquire" the lock. One-time check
+   before `--submit`: run the `.sub`'s flock line from two different nodes
+   against a scratch file under the same filesystem as
+   `src/results/`, or check `mount | grep -E 'flock|nfs'`. The runbook's
+   single-launcher discipline plus semantic job-name dedup makes collisions
+   unlikely regardless.
+2. **Witness availability.** Tasks 22/32 need a hashed *terminal* k30_r2
+   status and a peak18/sek prices witness in `~/EVSP-DR/src/results`; task 24
+   needs k30_r4. Which of the 8 completed 867334 cells (or older terminal
+   runs) qualify is only knowable on the cluster; WAIT_NO_WITNESS handles
+   absences cleanly. Expect the witness scan (recursive JSON load of the
+   legacy results tree, four times per job start) to take minutes on NFS.
+3. **Do not resubmit the failed legacy indices** (`sbatch --array=22,24,32
+   submit_cg_bigtariffs.sub` per the old HANDOFF A1 advice). The old reader
+   would crash again without modifying journals, but the crash tracebacks
+   would extend `cg-bigtar_867334_{22,24,32}.out/.err`, changing archived-log
+   hashes and hence the `migration_id`; an already-applied migration would
+   then fail closed and need operator attention.
+4. **Preemption during the short migration window itself** (between the raw
+   archive landing and the status commit marker) fails closed on requeue
+   ("destination status is missing but migration artifacts exist") and
+   requires a human to preserve the orphans and pick a new output path. This
+   is by design (fail-closed provenance) — just be aware the recovery is
+   self-healing for pricer preemption, not for migration preemption.
+5. **Python 3.12 conda fallback order.** The `.sub` activates the first env
+   that exists and *then* asserts 3.12; if `/home/nc437/evsp_env` is still a
+   3.10 env the job fatals immediately. The runbook already treats the first
+   submissions as the real 3.12 check against the damaged tails.
+6. **Real damaged-tail classes.** Local tests cover truncated JSON,
+   concatenated-then-truncated records, non-UTF8, and non-object tails; the
+   actual task-22/24/32 bytes are only on Unicorn. A refusal there is
+   evidence to preserve, per the runbook.
+
+## 4. Optional suggestions (do not block the recovery launch)
+
+- Dead code in `exact_pricer_expanded.py`: the unreachable second `return`
+  block at the end of `min_reduced_cost_route` (stale pre-refactor shape),
+  and the `if iters_csv: iters_csv.close()` / `if journal: journal.close()`
+  calls inside the snapshot-reconciliation section, where both handles are
+  still `None` since f85798c moved handle-opening after that block.
+- `_common_prefix_size` is a pure-Python byte loop; on multi-MB journals the
+  preview+apply pair costs a few seconds. Fine for this recovery; consider
+  `os.path.commonprefix`-style chunking if reused on bigger artifacts.
+- The task->cell mapping lives in both the launcher and the `.sub` (each
+  validates independently). The new mapping test pins them together; merging
+  them into one source of truth would still be cleaner.
+- `run_cg_snapshot_control.TERMINAL_STOP_REASONS` excludes `master_failed`,
+  so a deterministic master failure would be re-attempted every runner pass.
+  With fix 1, wall-exhausted stops no longer masquerade as `master_failed`,
+  which removes the common case; a retry cap would remove the rest.
+- The `.sub`'s fallback `#SBATCH -o src/cluster_logs/legacy_recovery/...`
+  path only exists relative to the repo; direct `sbatch` submission from
+  elsewhere (bypassing the launcher, which overrides `--output`) would fail
+  to start. Harmless given the documented launcher-only flow.
+
+## 5. Exact tests run and results
+
+Environment: Python 3.12.3, `numpy==2.2.6 pandas==2.3.3 scipy==1.15.3
+matplotlib==3.10.9` (pinned per `requirements-unicorn.txt`), pytest 9.x,
+Linux; repository clean at each run.
+
+1. `cd tests && python3 -m pytest -q` at `f85798c` (pre-change baseline):
+   **204 passed, 23 subtests passed** in 20.2s.
+2. End-to-end migration CLI script (real `main()`, real `_tool_identity`,
+   synthetic legacy tree): read-only plan leaves sources byte-identical;
+   `--apply` archives byte-identical raw copies + quarantined tails; re-apply
+   idempotent; idempotent after journal extension; idempotent after simulated
+   preemption mid-append plus pricer-style repair; missing witness exits 2
+   matching the WAIT grep; conflicting witnesses exit 2 NOT matching the WAIT
+   grep. **All passed.**
+3. Cross-process lock script: contention refused with owner diagnostics;
+   SIGKILL of the holder releases the lock for a requeue. **Passed.**
+4. Live preemption simulation on `Practice_Custom_TwoDuty_13301_13302.csv`:
+   fresh run SIGKILLed mid-CG (journal 433 columns), `--resume` completed
+   (417 iterations, 7,813 columns, `final_lp_source=final_pool_resolve`),
+   `iters.csv` elapsed monotone across attempts, rerun without `--resume`
+   refused, concurrent duplicate refused by the output lock. **Passed.**
+5. `bash -n` and `shellcheck -S warning` on both recovery scripts: **clean**.
+6. Regression validity: `test_wall_expiry_between_master_attempts_is_labeled_wall_limit`
+   **fails against unmodified f85798c** (observed `master_failed`) and passes
+   with fix 1.
+7. `cd tests && python3 -m pytest -q` after the fixes on
+   `cursor/recovery-audit`: **213 passed, 28 subtests passed** in 20.7s
+   (baseline 204 + 2 wall-limit labeling tests + 7 recovery-script tests).

--- a/src/exact_pricer_expanded.py
+++ b/src/exact_pricer_expanded.py
@@ -1157,12 +1157,10 @@ def run_cg(args) -> dict:
                 route_trip_ids=[r["trips"] for r in routes],
             )
             lp = None
-            wall_exhausted_mid_master = False
             for method in method_order:
                 try:
                     method_limit = _remaining_wall_s(reserve_s=30.0)
                     if method_limit is not None and method_limit <= 0.0:
-                        wall_exhausted_mid_master = True
                         break
                     lp = solve_restricted_master_lp(
                         trip_ids=trips,
@@ -1178,11 +1176,13 @@ def run_cg(args) -> dict:
                     print(f"[EXACT] master failed with {method}: {exc}; "
                           "retrying with next method", flush=True)
             if lp is None:
-                if wall_exhausted_mid_master:
-                    # The wall budget expired between master attempts.  This is
-                    # a graceful timed stop, not evidence that every master
-                    # method failed; label it honestly so resumable wall stops
-                    # are never recorded as solver failures.
+                # Evaluate wall exhaustion at this exit path itself: the final
+                # method attempt may have consumed the remaining budget before
+                # raising, and there is no later loop iteration to notice.  A
+                # timed-out attempt is a graceful, resumable wall stop, not
+                # evidence that every master method failed.
+                remaining_wall_s = _remaining_wall_s(reserve_s=30.0)
+                if remaining_wall_s is not None and remaining_wall_s <= 0.0:
                     print(f"[EXACT] cumulative wall limit {args.wall_limit_s}s "
                           "reached during the master solve — stopping "
                           "gracefully (partial result saved)", flush=True)

--- a/src/exact_pricer_expanded.py
+++ b/src/exact_pricer_expanded.py
@@ -1157,10 +1157,12 @@ def run_cg(args) -> dict:
                 route_trip_ids=[r["trips"] for r in routes],
             )
             lp = None
+            wall_exhausted_mid_master = False
             for method in method_order:
                 try:
                     method_limit = _remaining_wall_s(reserve_s=30.0)
                     if method_limit is not None and method_limit <= 0.0:
+                        wall_exhausted_mid_master = True
                         break
                     lp = solve_restricted_master_lp(
                         trip_ids=trips,
@@ -1176,9 +1178,19 @@ def run_cg(args) -> dict:
                     print(f"[EXACT] master failed with {method}: {exc}; "
                           "retrying with next method", flush=True)
             if lp is None:
-                print("[EXACT] all master methods failed — stopping uncertified",
-                      flush=True)
-                stop_reason = "master_failed"
+                if wall_exhausted_mid_master:
+                    # The wall budget expired between master attempts.  This is
+                    # a graceful timed stop, not evidence that every master
+                    # method failed; label it honestly so resumable wall stops
+                    # are never recorded as solver failures.
+                    print(f"[EXACT] cumulative wall limit {args.wall_limit_s}s "
+                          "reached during the master solve — stopping "
+                          "gracefully (partial result saved)", flush=True)
+                    stop_reason = "wall_limit"
+                else:
+                    print("[EXACT] all master methods failed — stopping "
+                          "uncertified", flush=True)
+                    stop_reason = "master_failed"
                 break
             last_good_lp_detail = _serialize_lp(
                 lp, routes, source="last_good_iterate",

--- a/src/migrate_legacy_exact_pool.py
+++ b/src/migrate_legacy_exact_pool.py
@@ -240,12 +240,99 @@ def _repair_report(original: bytes, repaired: bytes) -> dict:
     }
 
 
+def _strict_complete_dict_sequence(raw_line: bytes) -> tuple[bytes, int] | None:
+    """Normalize one line containing only two or more complete JSON objects.
+
+    A legacy writer could be preempted after persisting a complete object but
+    before its trailing newline.  The old resume reader accepted that valid
+    EOF object, then append mode joined the next object directly to it.  This
+    helper recognizes only the lossless ``{...}{...}`` case: the whole
+    physical line must decode as dictionary objects with no partial suffix or
+    other junk.  Ambiguous data returns ``None`` and remains subject to the
+    normal fail-closed reader.
+    """
+
+    try:
+        text = raw_line.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    decoder = json.JSONDecoder()
+    position = 0
+    serialized: list[str] = []
+    while True:
+        while position < len(text) and text[position].isspace():
+            position += 1
+        if position >= len(text):
+            break
+        start = position
+        try:
+            value, position = decoder.raw_decode(text, position)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(value, dict):
+            return None
+        serialized.append(text[start:position].strip())
+    if len(serialized) < 2:
+        return None
+    normalized = "".join(f"{value}\n" for value in serialized).encode("utf-8")
+    return normalized, len(serialized)
+
+
+def _normalize_lossless_interior_sequences(journal: Path) -> list[dict]:
+    """Normalize unambiguous legacy concatenations on a staged working copy.
+
+    Current-code resume remains strict.  This migration-only pass runs after
+    the original journal has been copied and hashed.  It changes a malformed
+    interior physical line only when every byte is a sequence of two or more
+    complete dictionary objects; all partial, non-object, non-UTF-8, or junk
+    cases are left untouched so :func:`read_jsonl_records` refuses them.
+    """
+
+    original = journal.read_bytes()
+    lines = original.splitlines(keepends=True)
+    nonempty = [index for index, line in enumerate(lines) if line.strip()]
+    if not nonempty:
+        return []
+    last_nonempty = nonempty[-1]
+    output: list[bytes] = []
+    repairs: list[dict] = []
+    offset = 0
+    for index, line in enumerate(lines):
+        replacement = None
+        recovered_objects = 0
+        if index < last_nonempty and line.strip():
+            try:
+                json.loads(line)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                decoded = _strict_complete_dict_sequence(line)
+                if decoded is not None:
+                    replacement, recovered_objects = decoded
+        if replacement is None:
+            output.append(line)
+        else:
+            output.append(replacement)
+            repairs.append({
+                "kind": "complete_concatenated_dicts",
+                "original_offset": offset,
+                "original_line_bytes": len(line),
+                "original_line_sha256": _sha256_bytes(line),
+                "normalized_line_bytes": len(replacement),
+                "normalized_line_sha256": _sha256_bytes(replacement),
+                "recovered_objects": recovered_objects,
+            })
+        offset += len(line)
+    if repairs:
+        atomic_write_bytes(journal, b"".join(output))
+    return repairs
+
+
 def _repair_and_validate_working_copies(
     journal: Path, iters: Path, trip_ids: list[int],
 ) -> dict:
     """Repair archived working copies and validate their usable prefix."""
 
     journal_before = journal.read_bytes()
+    interior_normalizations = _normalize_lossless_interior_sequences(journal)
     records = read_jsonl_records(
         journal,
         repair_trailing=True,
@@ -275,6 +362,7 @@ def _repair_and_validate_working_copies(
                 **_repair_report(journal_before, journal_after),
                 "complete_records": len(records),
                 "unique_incidences": len(pool),
+                "lossless_interior_normalizations": interior_normalizations,
             },
             "iters": {
                 **_repair_report(iters_before, iters_after),

--- a/src/migrate_legacy_exact_pool.py
+++ b/src/migrate_legacy_exact_pool.py
@@ -240,16 +240,18 @@ def _repair_report(original: bytes, repaired: bytes) -> dict:
     }
 
 
-def _strict_complete_dict_sequence(raw_line: bytes) -> tuple[bytes, int] | None:
-    """Normalize one line containing only two or more complete JSON objects.
+def _strict_complete_dict_sequence(
+    raw_line: bytes, *, minimum_objects: int = 2,
+) -> tuple[bytes, int] | None:
+    """Normalize one line containing only complete JSON dictionary objects.
 
     A legacy writer could be preempted after persisting a complete object but
     before its trailing newline.  The old resume reader accepted that valid
     EOF object, then append mode joined the next object directly to it.  This
-    helper recognizes only the lossless ``{...}{...}`` case: the whole
-    physical line must decode as dictionary objects with no partial suffix or
-    other junk.  Ambiguous data returns ``None`` and remains subject to the
-    normal fail-closed reader.
+    helper recognizes only a fully consumed sequence of dictionary objects;
+    callers choose whether one object or a true ``{...}{...}`` concatenation
+    is required.  Any partial suffix or other junk returns ``None`` and
+    remains subject to the normal fail-closed reader.
     """
 
     try:
@@ -272,20 +274,28 @@ def _strict_complete_dict_sequence(raw_line: bytes) -> tuple[bytes, int] | None:
         if not isinstance(value, dict):
             return None
         serialized.append(text[start:position].strip())
-    if len(serialized) < 2:
+    if len(serialized) < minimum_objects:
         return None
     normalized = "".join(f"{value}\n" for value in serialized).encode("utf-8")
     return normalized, len(serialized)
 
 
-def _normalize_lossless_interior_sequences(journal: Path) -> list[dict]:
-    """Normalize unambiguous legacy concatenations on a staged working copy.
+def _normalize_recoverable_legacy_lines(journal: Path) -> list[dict]:
+    """Recover all valid objects from unambiguous legacy physical lines.
 
     Current-code resume remains strict.  This migration-only pass runs after
-    the original journal has been copied and hashed.  It changes a malformed
-    interior physical line only when every byte is a sequence of two or more
-    complete dictionary objects; all partial, non-object, non-UTF-8, or junk
-    cases are left untouched so :func:`read_jsonl_records` refuses them.
+    the original journal has been copied and hashed.  It changes an interior
+    physical line only when every byte is a sequence of two or more complete
+    dictionary objects.  At any position, including EOF, it may also remove
+    an all-NUL prefix followed by one or more completely decodable dictionary
+    objects.  The latter handles an observed legacy preemption artifact
+    without discarding a valid column.
+    All partial, mixed-prefix, non-object, non-UTF-8, or junk cases are left
+    untouched for :func:`read_jsonl_records` to refuse as interior corruption
+    or handle under its pre-existing archived-tail quarantine policy.
+    Recovery is lossless at the JSON-object level, while normalization may
+    remove NUL padding or inter-object whitespace; the original bytes are
+    retained in the migration's raw archive and attested separately.
     """
 
     original = journal.read_bytes()
@@ -300,25 +310,46 @@ def _normalize_lossless_interior_sequences(journal: Path) -> list[dict]:
     for index, line in enumerate(lines):
         replacement = None
         recovered_objects = 0
-        if index < last_nonempty and line.strip():
+        kind = None
+        extra_metadata = {}
+        if line.strip():
             try:
                 json.loads(line)
             except (UnicodeDecodeError, json.JSONDecodeError):
-                decoded = _strict_complete_dict_sequence(line)
-                if decoded is not None:
-                    replacement, recovered_objects = decoded
+                if index < last_nonempty:
+                    decoded = _strict_complete_dict_sequence(line)
+                    if decoded is not None:
+                        replacement, recovered_objects = decoded
+                        kind = "complete_concatenated_dicts"
+                if replacement is None:
+                    nul_prefix_bytes = len(line) - len(line.lstrip(b"\0"))
+                    if nul_prefix_bytes:
+                        decoded = _strict_complete_dict_sequence(
+                            line[nul_prefix_bytes:], minimum_objects=1,
+                        )
+                        if decoded is not None:
+                            replacement, recovered_objects = decoded
+                            kind = "nul_prefix_before_complete_dicts"
+                            prefix = line[:nul_prefix_bytes]
+                            extra_metadata = {
+                                "discarded_nul_prefix_bytes": nul_prefix_bytes,
+                                "discarded_nul_prefix_sha256": _sha256_bytes(
+                                    prefix
+                                ),
+                            }
         if replacement is None:
             output.append(line)
         else:
             output.append(replacement)
             repairs.append({
-                "kind": "complete_concatenated_dicts",
+                "kind": kind,
                 "original_offset": offset,
                 "original_line_bytes": len(line),
                 "original_line_sha256": _sha256_bytes(line),
                 "normalized_line_bytes": len(replacement),
                 "normalized_line_sha256": _sha256_bytes(replacement),
                 "recovered_objects": recovered_objects,
+                **extra_metadata,
             })
         offset += len(line)
     if repairs:
@@ -332,7 +363,7 @@ def _repair_and_validate_working_copies(
     """Repair archived working copies and validate their usable prefix."""
 
     journal_before = journal.read_bytes()
-    interior_normalizations = _normalize_lossless_interior_sequences(journal)
+    line_normalizations = _normalize_recoverable_legacy_lines(journal)
     records = read_jsonl_records(
         journal,
         repair_trailing=True,
@@ -362,7 +393,7 @@ def _repair_and_validate_working_copies(
                 **_repair_report(journal_before, journal_after),
                 "complete_records": len(records),
                 "unique_incidences": len(pool),
-                "lossless_interior_normalizations": interior_normalizations,
+                "legacy_line_normalizations": line_normalizations,
             },
             "iters": {
                 **_repair_report(iters_before, iters_after),

--- a/src/submit_legacy_bigtariff_recovery.sub
+++ b/src/submit_legacy_bigtariff_recovery.sub
@@ -59,7 +59,10 @@ OUTDIR="$ROOT/src/results/legacy_recovery/job${ARRAY_JOB}/c${EXPECTED_COMMIT:0:1
 OUT="$OUTDIR/${NAME}_${TAG}.json"
 mkdir -p "$OUTDIR"
 command -v flock >/dev/null 2>&1 || fatal "flock is unavailable"
-exec 9>"$OUT.recovery.lock"
+# Open the lock fd in append mode: an O_TRUNC open would erase the current
+# owner's diagnostic record before this job even attempts (and loses) the
+# flock race.  The kernel lock, not the file contents, decides ownership.
+exec 9>>"$OUT.recovery.lock"
 if ! flock -n 9; then
   echo "[RECOVERY] SKIP_LOCKED another migration/pricer owns $OUT"
   exit 0

--- a/src/submit_legacy_bigtariff_recovery.sub
+++ b/src/submit_legacy_bigtariff_recovery.sub
@@ -81,9 +81,17 @@ source /share/apps/software/anaconda3/etc/profile.d/conda.sh \
 activated=""
 for ENV in "${EVSP_CONDA_ENV:-}" /home/nc437/evsp_env evsp_env312 evsp312 evsp_env py312; do
   [ -n "$ENV" ] || continue
-  if conda activate "$ENV" 2>/dev/null; then activated=$ENV; break; fi
+  conda activate "$ENV" 2>/dev/null || continue
+  # An environment that activates but is not the validated Python 3.12
+  # runtime (e.g. a legacy 3.10 evsp_env) must not stop the search: keep
+  # trying later candidates instead of failing the whole job.
+  if python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 12) else 1)' 2>/dev/null; then
+    activated=$ENV
+    break
+  fi
+  conda deactivate 2>/dev/null || true
 done
-[ -n "$activated" ] || fatal "no project conda environment could be activated"
+[ -n "$activated" ] || fatal "no Python 3.12 project conda environment could be activated"
 python -c 'import sys; assert sys.version_info[:2] == (3, 12), sys.version' \
   || fatal "recovery campaign requires the validated Python 3.12 runtime"
 echo "[RECOVERY] conda=$activated $(python -V 2>&1)"

--- a/tests/test_durable_io.py
+++ b/tests/test_durable_io.py
@@ -45,6 +45,20 @@ class DurableIoTests(unittest.TestCase):
             with self.assertRaisesRegex(DurableFileError, "before EOF"):
                 read_jsonl_records(path, repair_trailing=True)
 
+    def test_current_resume_refuses_complete_concatenation_before_eof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "columns.jsonl"
+            first = {"trips": [1], "cost": 1.0}
+            second = {"trips": [2], "cost": 2.0}
+            third = {"trips": [3], "cost": 3.0}
+            path.write_text(
+                json.dumps(first) + json.dumps(second) + "\n"
+                + json.dumps(third) + "\n"
+            )
+
+            with self.assertRaisesRegex(DurableFileError, "before EOF"):
+                read_jsonl_records(path, repair_trailing=True)
+
     def test_valid_final_jsonl_record_gets_newline_before_append(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "columns.jsonl"

--- a/tests/test_durable_io.py
+++ b/tests/test_durable_io.py
@@ -59,6 +59,32 @@ class DurableIoTests(unittest.TestCase):
             with self.assertRaisesRegex(DurableFileError, "before EOF"):
                 read_jsonl_records(path, repair_trailing=True)
 
+    def test_current_resume_refuses_nul_prefixed_record_before_eof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "columns.jsonl"
+            first = {"trips": [1], "cost": 1.0}
+            second = {"trips": [2], "cost": 2.0}
+            path.write_bytes(
+                b"\0" * 1014 + (json.dumps(first) + "\n").encode()
+                + (json.dumps(second) + "\n").encode()
+            )
+
+            with self.assertRaisesRegex(DurableFileError, "before EOF"):
+                read_jsonl_records(path, repair_trailing=True)
+
+    def test_current_resume_refuses_nul_prefixed_final_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "columns.jsonl"
+            first = {"trips": [1], "cost": 1.0}
+            second = {"trips": [2], "cost": 2.0}
+            path.write_bytes(
+                (json.dumps(first) + "\n").encode()
+                + b"\0" * 1014 + json.dumps(second).encode()
+            )
+
+            with self.assertRaisesRegex(DurableFileError, "malformed final"):
+                read_jsonl_records(path, repair_trailing=True)
+
     def test_valid_final_jsonl_record_gets_newline_before_append(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "columns.jsonl"

--- a/tests/test_exact_pricer_resume.py
+++ b/tests/test_exact_pricer_resume.py
@@ -298,6 +298,18 @@ class ExactPricerResumeTests(unittest.TestCase):
             )
         self.assertEqual(result["stop_reason"], "wall_limit")
 
+    def test_wall_expiry_during_final_master_attempt_is_labeled_wall_limit(self):
+        # Boundary case: every method still receives a positive time limit
+        # (170s, 110s, 50s), so no mid-loop exhaustion break ever fires; the
+        # third and FINAL attempt consumes the remaining budget and then
+        # raises.  There is no later loop iteration to notice the expiry, so
+        # the exit path itself must classify this as a wall stop.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_master_labeling_case(
+                tmp, wall_limit_s=200, master_seconds_per_attempt=60.0,
+            )
+        self.assertEqual(result["stop_reason"], "wall_limit")
+
     def test_exhausting_all_master_methods_stays_labeled_master_failed(self):
         # With ample wall budget, failing every master method is a genuine
         # master failure and must keep its uncertified label.

--- a/tests/test_exact_pricer_resume.py
+++ b/tests/test_exact_pricer_resume.py
@@ -226,6 +226,87 @@ class ExactPricerResumeTests(unittest.TestCase):
 
             self.assertEqual(result["columns"], 2)
 
+    def _run_master_labeling_case(self, tmp, *, wall_limit_s,
+                                  master_seconds_per_attempt):
+        """Resume a one-column pool against a failing master under fake time.
+
+        Returns the terminal result written by ``run_cg``.  Every master
+        attempt raises after advancing the fake clock, so the run must decide
+        between the honest ``wall_limit`` and ``master_failed`` labels.
+        """
+
+        out = Path(tmp) / "run.json"
+        status = self._status()
+        status["trip_ids"] = [1]
+        status["wall_s"] = 0.0
+        status["iterations"] = 0
+        out.write_text(json.dumps(status))
+        record = dict(self._record())
+        record["trips"] = [1]
+        Path(str(out) + ".columns.jsonl").write_text(
+            json.dumps(record) + "\n"
+        )
+        args = self._args(out)
+        args.wall_limit_s = wall_limit_s
+
+        class _FakeTime:
+            def __init__(self):
+                self.now = 1000.0
+
+            def time(self):
+                return self.now
+
+        fake_time = _FakeTime()
+
+        def _failing_master(*_args, **_kwargs):
+            fake_time.now += master_seconds_per_attempt
+            raise RuntimeError("synthetic master failure")
+
+        problem = SimpleNamespace(trips=[1], adjacency={})
+        network = SimpleNamespace(node_meta=[], n_arcs=0)
+        provenance = {
+            "instance_sha256": "instance-hash",
+            "prices_sha256": "prices-hash",
+        }
+        with (
+            patch.object(exact, "time", fake_time),
+            patch.object(exact, "build_problem", return_value=problem),
+            patch.object(exact, "load_station_hourly_prices", return_value={}),
+            patch.object(exact, "ExpandedNetwork", return_value=network),
+            patch.object(exact, "_provenance", return_value=provenance),
+            patch.object(
+                exact, "direct_singleton_seed_records",
+                return_value=([], [1]),
+            ),
+            patch.object(
+                exact, "build_route_incidence", return_value=None,
+            ),
+            patch.object(
+                exact, "solve_restricted_master_lp",
+                side_effect=_failing_master,
+            ),
+        ):
+            return exact.run_cg(args)
+
+    def test_wall_expiry_between_master_attempts_is_labeled_wall_limit(self):
+        # First attempt consumes the whole budget and fails; the second
+        # method sees no remaining wall time.  The stop must be recorded as
+        # the graceful timed stop it is, not as a solver failure.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_master_labeling_case(
+                tmp, wall_limit_s=200, master_seconds_per_attempt=180.0,
+            )
+        self.assertEqual(result["stop_reason"], "wall_limit")
+
+    def test_exhausting_all_master_methods_stays_labeled_master_failed(self):
+        # With ample wall budget, failing every master method is a genuine
+        # master failure and must keep its uncertified label.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_master_labeling_case(
+                tmp, wall_limit_s=100000, master_seconds_per_attempt=1.0,
+            )
+        self.assertEqual(result["stop_reason"], "master_failed")
+
     def test_recovers_orphan_snapshot_only_from_matching_partial_status(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "run.json"

--- a/tests/test_legacy_recovery_scripts.py
+++ b/tests/test_legacy_recovery_scripts.py
@@ -166,6 +166,71 @@ class LegacyRecoveryScriptTests(unittest.TestCase):
                 self.assertEqual(launcher["price_rel"], price)
                 self.assertEqual(launcher["source_cell"], f"{name}_{tag}")
 
+    def _extract_conda_selection_block(self) -> str:
+        match = re.search(
+            r'\nactivated=""\n.*?\ndone\n', self.job_text, re.DOTALL
+        )
+        self.assertIsNotNone(
+            match, "job script lost its conda environment selection loop"
+        )
+        return match.group(0)
+
+    def _run_conda_selection(self, *, env_pythons: dict) -> str:
+        """Execute the .sub's real selection loop with mocked conda/python.
+
+        ``env_pythons`` maps activatable environment names to the Python
+        version their activation would expose.  Returns the selected
+        environment name ('' when no candidate was accepted).
+        """
+
+        cases = "\n".join(
+            f'        {name}) CURRENT_PY={version}; return 0 ;;'
+            for name, version in env_pythons.items()
+        )
+        harness = (
+            "set -euo pipefail\n"
+            "CURRENT_PY=\"\"\n"
+            "conda() {\n"
+            "  case \"$1\" in\n"
+            "    activate)\n"
+            "      case \"$2\" in\n"
+            f"{cases}\n"
+            "        *) return 1 ;;\n"
+            "      esac ;;\n"
+            "    deactivate) CURRENT_PY=\"\"; return 0 ;;\n"
+            "  esac\n"
+            "}\n"
+            "python() { [ \"$CURRENT_PY\" = 3.12 ]; }\n"
+            + self._extract_conda_selection_block()
+            + "echo \"SELECTED=$activated\"\n"
+        )
+        completed = subprocess.run(
+            ["/bin/bash", "-c", harness], text=True, capture_output=True,
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        match = re.search(r"SELECTED=(.*)", completed.stdout)
+        self.assertIsNotNone(match, completed.stdout)
+        return match.group(1).strip()
+
+    def test_conda_fallback_skips_activatable_non_python312_environment(self):
+        # A legacy 3.10 environment that activates first must not stop the
+        # search before the validated 3.12 candidate is tried.
+        selected = self._run_conda_selection(env_pythons={
+            "/home/nc437/evsp_env": "3.10",
+            "evsp_env312": "3.12",
+        })
+        self.assertEqual(selected, "evsp_env312")
+
+    def test_conda_fallback_selects_nothing_without_a_python312_candidate(self):
+        # With only non-3.12 environments activatable, the loop must leave
+        # $activated empty so the job fatals instead of running mismatched
+        # Python against the recovery artifacts.
+        selected = self._run_conda_selection(env_pythons={
+            "/home/nc437/evsp_env": "3.10",
+        })
+        self.assertEqual(selected, "")
+
     def test_launcher_defaults_to_dry_run_and_pins_both_commits(self):
         self.assertIn("SUBMIT=0", self.launcher_text)
         self.assertIn("--submit) SUBMIT=1", self.launcher_text)

--- a/tests/test_legacy_recovery_scripts.py
+++ b/tests/test_legacy_recovery_scripts.py
@@ -1,0 +1,183 @@
+"""Guardrails for the legacy big-tariff recovery launcher and Slurm job.
+
+These scripts encode the requeue, locking, and WAIT-vs-fatal semantics of the
+task-22/24/32 recovery.  They previously had no test coverage, so regressions
+in the task->cell mapping or the witness-wait classification could only be
+noticed on Unicorn.
+"""
+
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from migrate_legacy_exact_pool import MigrationError, discover_witness  # noqa: E402
+
+
+LAUNCHER = REPO_ROOT / "src" / "launch_legacy_bigtariff_recovery.sh"
+JOB = REPO_ROOT / "src" / "submit_legacy_bigtariff_recovery.sub"
+
+# The original 40-task array arithmetic from submit_cg_bigtariffs.sub:
+# TASK0 = task - 1; INST = TASK0 % 10 (0-5 -> k30 r1-6, 6-9 -> k40 r1-4);
+# TARIFF_IDX = TASK0 // 10 over (peak08, peak12, peak18, sek).
+ORIGINAL_TAGS = ("peak08", "peak12", "peak18", "sek")
+ORIGINAL_PRICES = (
+    "hourly_prices_single_peak_08.csv",
+    "hourly_prices_single_peak_12.csv",
+    "hourly_prices_single_peak_18.csv",
+    "hourly_prices_transdev_sek.csv",
+)
+
+
+def original_array_cell(task: int) -> tuple[str, str, str]:
+    task0 = task - 1
+    inst = task0 % 10
+    tariff_idx = task0 // 10
+    if inst <= 5:
+        name = f"Practice_Custom_DutyUnion_k30_r{inst + 1}"
+    else:
+        name = f"Practice_Custom_DutyUnion_k40_r{inst - 5}"
+    return name, ORIGINAL_TAGS[tariff_idx], ORIGINAL_PRICES[tariff_idx]
+
+
+class LegacyRecoveryScriptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.launcher_text = LAUNCHER.read_text()
+        cls.job_text = JOB.read_text()
+
+    def test_scripts_parse_under_bash(self):
+        for script in (LAUNCHER, JOB):
+            with self.subTest(script=script.name):
+                subprocess.run(["/bin/bash", "-n", str(script)], check=True)
+
+    def test_job_is_requeue_safe_and_time_limited(self):
+        self.assertIn("#SBATCH --requeue", self.job_text)
+        self.assertIn("#SBATCH --open-mode=append", self.job_text)
+        self.assertIn("#SBATCH -t 7-00:00:00", self.job_text)
+        self.assertIn("#SBATCH --partition=default_partition", self.job_text)
+        self.assertIn("--mail-type=REQUEUE,FAIL,TIME_LIMIT", self.job_text)
+        self.assertIn("set -euo pipefail", self.job_text)
+        self.assertIn("--resume", self.job_text)
+
+    def test_job_lock_fd_uses_append_mode(self):
+        # An O_TRUNC open (exec 9>) would wipe the current owner's diagnostic
+        # record before the duplicate job loses the flock race.
+        self.assertIn('exec 9>>"$OUT.recovery.lock"', self.job_text)
+        self.assertNotRegex(self.job_text, r'exec 9>"')
+
+    def test_job_preserves_legacy_identity_parameters(self):
+        # The migrated status is identity-checked against these exact model
+        # parameters; the job must reproduce the original campaign's values
+        # and must not override the defaults the legacy campaign relied on.
+        self.assertIn("--soc-step 15", self.job_text)
+        self.assertIn("--block-min 10", self.job_text)
+        self.assertIn("--rc-eps 0.0001", self.job_text)
+        for forbidden in ("--master-sense", "--g-kwh", "--charge-kw",
+                          "--min-soc-frac"):
+            self.assertNotIn(forbidden, self.job_text)
+
+    def _job_wait_pattern(self) -> str:
+        match = re.search(r"grep -Eq '([^']+)'", self.job_text)
+        self.assertIsNotNone(match, "job script lost its WAIT grep")
+        return match.group(1)
+
+    def test_wait_grep_matches_missing_witness_but_not_conflicts(self):
+        pattern = self._job_wait_pattern()
+        legacy = {
+            "csv": "instance.csv",
+            "prices_csv": "prices.csv",
+            "soc_step": 15.0,
+            "block_min": 10,
+            "g_kwh": 300.0,
+            "charge_kw": 300,
+            "min_soc_frac": 0.0,
+            "master_sense": "partition",
+            "trip_ids": [1, 2],
+        }
+        # A missing witness must be classified as the clean WAIT state.
+        with self.assertRaises(MigrationError) as ctx:
+            discover_witness(
+                [], legacy,
+                path_field="csv", hash_field="instance_sha256",
+                expected_hash="a" * 64, require_trip_ids=True,
+            )
+        self.assertRegex(str(ctx.exception), pattern)
+        # A conflict must stay fatal: its message must NOT match the WAIT
+        # pattern, otherwise conflicting provenance would exit 0 and wait.
+        conflict_message = (
+            "conflicting instance_sha256 witnesses for instance.csv: "
+            "['aa..', 'bb..']"
+        )
+        self.assertNotRegex(conflict_message, pattern)
+
+    def _launcher_cells(self) -> dict:
+        cells = {}
+        pattern = re.compile(
+            r'(\d+)\)\s+SHORT="([^"]+)";\s*'
+            r'CSV_REL="([^"]+)";\s*'
+            r'PRICE_REL="([^"]+)";\s*'
+            r'SOURCE_CELL="([^"]+)"',
+        )
+        for match in pattern.finditer(self.launcher_text):
+            cells[int(match.group(1))] = {
+                "short": match.group(2),
+                "csv_rel": match.group(3),
+                "price_rel": match.group(4),
+                "source_cell": match.group(5),
+            }
+        return cells
+
+    def _job_cells(self) -> dict:
+        cells = {}
+        pattern = re.compile(
+            r'(\d+)\)\s+NAME="([^"]+)";\s*TAG="([^"]+)";\s*'
+            r'PRICE="([^"]+)"',
+        )
+        for match in pattern.finditer(self.job_text):
+            cells[int(match.group(1))] = {
+                "name": match.group(2),
+                "tag": match.group(3),
+                "price": match.group(4),
+            }
+        return cells
+
+    def test_task_mapping_matches_original_array_in_both_scripts(self):
+        launcher_cells = self._launcher_cells()
+        job_cells = self._job_cells()
+        self.assertEqual(sorted(launcher_cells), [22, 24, 32])
+        self.assertEqual(sorted(job_cells), [22, 24, 32])
+        for task in (22, 24, 32):
+            with self.subTest(task=task):
+                name, tag, price = original_array_cell(task)
+                job = job_cells[task]
+                self.assertEqual(job["name"], name)
+                self.assertEqual(job["tag"], tag)
+                self.assertEqual(job["price"], price)
+                launcher = launcher_cells[task]
+                self.assertEqual(
+                    launcher["csv_rel"], f"duty_unions_big/{name}.csv"
+                )
+                self.assertEqual(launcher["price_rel"], price)
+                self.assertEqual(launcher["source_cell"], f"{name}_{tag}")
+
+    def test_launcher_defaults_to_dry_run_and_pins_both_commits(self):
+        self.assertIn("SUBMIT=0", self.launcher_text)
+        self.assertIn("--submit) SUBMIT=1", self.launcher_text)
+        self.assertIn(
+            'SOURCE_HEAD" = "$LEGACY_COMMIT"', self.launcher_text.replace(
+                '[ "$', '')
+        )
+        self.assertIn("EVSP_EXPECTED_COMMIT=$COMMIT", self.launcher_text)
+        # The compute job re-verifies both checkouts on every (re)start.
+        self.assertIn('"$actual_commit" = "$EXPECTED_COMMIT"', self.job_text)
+        self.assertIn('"$source_commit" = "$LEGACY_COMMIT"', self.job_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_migrate_legacy_exact_pool.py
+++ b/tests/test_migrate_legacy_exact_pool.py
@@ -222,6 +222,88 @@ class LegacyExactPoolMigrationTests(unittest.TestCase):
         self.assertEqual(self.journal.read_text(), original)
         self.assertFalse(self.destination.exists())
 
+    def test_losslessly_normalizes_complete_interior_dict_sequence(self):
+        preceding = (json.dumps(self.record1) + "\n").encode()
+        concatenated = (
+            json.dumps(self.record2) + json.dumps(self.record1) + "\n"
+        ).encode()
+        original = (
+            preceding + concatenated + (json.dumps(self.record2) + "\n").encode()
+        )
+        self.journal.write_bytes(original)
+
+        plan = self._plan()
+        preview_repairs = plan["repair_preview"]["journal"][
+            "lossless_interior_normalizations"
+        ]
+        self.assertEqual(len(preview_repairs), 1)
+        self.assertEqual(
+            preview_repairs[0]["original_offset"], len(preceding)
+        )
+        self.assertEqual(preview_repairs[0]["recovered_objects"], 2)
+        self.assertEqual(
+            preview_repairs[0]["original_line_sha256"],
+            hashlib.sha256(concatenated).hexdigest(),
+        )
+
+        attestation = apply_migration(plan)
+
+        self.assertEqual(self.journal.read_bytes(), original)
+        destination_journal = Path(str(self.destination) + ".columns.jsonl")
+        records = [
+            json.loads(line) for line in destination_journal.read_text().splitlines()
+        ]
+        self.assertEqual(
+            records, [self.record1, self.record2, self.record1, self.record2]
+        )
+        migrated = json.loads(self.destination.read_text())
+        self.assertEqual(migrated["columns"], 2)
+        self.assertFalse(migrated["certified_rc_optimal"])
+        self.assertIsNone(migrated["final_lp"])
+        self.assertTrue(attestation["repairs"]["journal"]["applied"])
+        self.assertEqual(
+            attestation["repairs"]["journal"][
+                "lossless_interior_normalizations"
+            ],
+            preview_repairs,
+        )
+        raw_journal = (
+            self.destination.parent
+            / f"{self.destination.name}.legacy_raw"
+            / "source_result.json.columns.jsonl"
+        )
+        self.assertEqual(raw_journal.read_bytes(), original)
+        repair = attestation["repairs"]["journal"]
+        changed_tail = raw_journal.parent / "journal_changed_tail.bin"
+        self.assertTrue(changed_tail.is_file())
+        self.assertEqual(changed_tail.stat().st_size, repair["original_tail_bytes"])
+        self.assertEqual(
+            hashlib.sha256(changed_tail.read_bytes()).hexdigest(),
+            repair["original_tail_sha256"],
+        )
+
+    def test_ambiguous_interior_sequences_still_fail_closed(self):
+        malformed_lines = (
+            json.dumps(self.record1) + '{"trips":',
+            json.dumps(self.record1) + "junk",
+            json.dumps(self.record1) + "[]",
+            json.dumps(self.record1) + json.dumps(self.record2) + "junk",
+            json.dumps(self.record1) + json.dumps(self.record2) + '{"trips":',
+        )
+        for index, malformed in enumerate(malformed_lines):
+            with self.subTest(malformed=malformed):
+                original = (
+                    malformed + "\n" + json.dumps(self.record2) + "\n"
+                )
+                self.journal.write_text(original)
+                self.destination = self.destination_dir / f"refused_{index}.json"
+
+                with self.assertRaisesRegex(DurableFileError, "before EOF"):
+                    self._plan()
+
+                self.assertEqual(self.journal.read_text(), original)
+                self.assertFalse(self.destination.exists())
+
     def test_missing_or_conflicting_witness_fails_closed(self):
         (self.results / "instance_witness.json").unlink()
         with self.assertRaisesRegex(MigrationError, "no authenticated"):

--- a/tests/test_migrate_legacy_exact_pool.py
+++ b/tests/test_migrate_legacy_exact_pool.py
@@ -234,7 +234,7 @@ class LegacyExactPoolMigrationTests(unittest.TestCase):
 
         plan = self._plan()
         preview_repairs = plan["repair_preview"]["journal"][
-            "lossless_interior_normalizations"
+            "legacy_line_normalizations"
         ]
         self.assertEqual(len(preview_repairs), 1)
         self.assertEqual(
@@ -263,7 +263,7 @@ class LegacyExactPoolMigrationTests(unittest.TestCase):
         self.assertTrue(attestation["repairs"]["journal"]["applied"])
         self.assertEqual(
             attestation["repairs"]["journal"][
-                "lossless_interior_normalizations"
+                "legacy_line_normalizations"
             ],
             preview_repairs,
         )
@@ -302,6 +302,115 @@ class LegacyExactPoolMigrationTests(unittest.TestCase):
                     self._plan()
 
                 self.assertEqual(self.journal.read_text(), original)
+                self.assertFalse(self.destination.exists())
+
+    def test_recovers_nul_prefixed_complete_interior_record(self):
+        preceding = (json.dumps(self.record1) + "\n").encode()
+        padded = b"\0" * 1014 + (json.dumps(self.record2) + "\n").encode()
+        following = (json.dumps(self.record1) + "\n").encode()
+        original = preceding + padded + following
+        self.journal.write_bytes(original)
+
+        plan = self._plan()
+        repairs = plan["repair_preview"]["journal"][
+            "legacy_line_normalizations"
+        ]
+        self.assertEqual(len(repairs), 1)
+        repair = repairs[0]
+        self.assertEqual(repair["kind"], "nul_prefix_before_complete_dicts")
+        self.assertEqual(repair["original_offset"], len(preceding))
+        self.assertEqual(
+            repair["original_line_sha256"], hashlib.sha256(padded).hexdigest()
+        )
+        self.assertEqual(repair["discarded_nul_prefix_bytes"], 1014)
+        self.assertEqual(
+            repair["discarded_nul_prefix_sha256"],
+            hashlib.sha256(b"\0" * 1014).hexdigest(),
+        )
+        self.assertEqual(repair["recovered_objects"], 1)
+
+        attestation = apply_migration(plan)
+
+        self.assertEqual(self.journal.read_bytes(), original)
+        destination_journal = Path(str(self.destination) + ".columns.jsonl")
+        records = [
+            json.loads(line) for line in destination_journal.read_text().splitlines()
+        ]
+        self.assertEqual(records, [self.record1, self.record2, self.record1])
+        self.assertEqual(
+            attestation["repairs"]["journal"][
+                "legacy_line_normalizations"
+            ],
+            repairs,
+        )
+        raw_journal = (
+            self.destination.parent
+            / f"{self.destination.name}.legacy_raw"
+            / "source_result.json.columns.jsonl"
+        )
+        self.assertEqual(raw_journal.read_bytes(), original)
+
+    def test_recovers_nul_prefixed_complete_final_records(self):
+        cases = (
+            [self.record2],
+            [self.record2, self.record1],
+        )
+        for index, recovered in enumerate(cases):
+            with self.subTest(recovered=len(recovered)):
+                preceding = (json.dumps(self.record1) + "\n").encode()
+                padded = b"\0" * 1014 + "".join(
+                    json.dumps(record) for record in recovered
+                ).encode()
+                original = preceding + padded
+                self.journal.write_bytes(original)
+                self.destination = (
+                    self.destination_dir / f"nul_final_{index}.json"
+                )
+
+                plan = self._plan()
+                repairs = plan["repair_preview"]["journal"][
+                    "legacy_line_normalizations"
+                ]
+                self.assertEqual(len(repairs), 1)
+                self.assertEqual(
+                    repairs[0]["kind"], "nul_prefix_before_complete_dicts"
+                )
+                self.assertEqual(
+                    repairs[0]["recovered_objects"], len(recovered)
+                )
+
+                apply_migration(plan)
+
+                destination_journal = Path(
+                    str(self.destination) + ".columns.jsonl"
+                )
+                records = [
+                    json.loads(line)
+                    for line in destination_journal.read_text().splitlines()
+                ]
+                self.assertEqual(records, [self.record1, *recovered])
+                self.assertEqual(self.journal.read_bytes(), original)
+
+    def test_ambiguous_nul_prefixed_interior_data_still_fails_closed(self):
+        damaged_lines = (
+            b"\0" * 16 + b'{"trips":',
+            b"\0" * 16 + (json.dumps(self.record1) + "junk").encode(),
+            b"\0" * 16 + b"x" + json.dumps(self.record1).encode(),
+        )
+        for index, damaged in enumerate(damaged_lines):
+            with self.subTest(damaged=damaged):
+                original = damaged + b"\n" + (
+                    json.dumps(self.record2) + "\n"
+                ).encode()
+                self.journal.write_bytes(original)
+                self.destination = (
+                    self.destination_dir / f"nul_refused_{index}.json"
+                )
+
+                with self.assertRaisesRegex(DurableFileError, "before EOF"):
+                    self._plan()
+
+                self.assertEqual(self.journal.read_bytes(), original)
                 self.assertFalse(self.destination.exists())
 
     def test_missing_or_conflicting_witness_fails_closed(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Independent audit of `f85798c` ("Harden exact CG preemption recovery") on `peel-and-price`, requested before launching the task-22/24/32 legacy recovery on Unicorn. Full findings, verification methodology, and operational checklist are in `AUDIT_RECOVERY_20260811.md` (added on this branch). The commit's core design — copy-only migration, split-status witness reconstruction, fail-closed provenance, narrow tail repair, publication ordering, and idempotent requeue behavior — was verified against synthetic fixtures and the committed sample instances on a local single-node VM (the actual damaged Unicorn artifacts were never inspected; see the report's evidence-basis note and section 3).

Fixes on this branch; none touch model semantics, provenance checks, or the legacy artifacts:

1. **`src/exact_pricer_expanded.py` — wall-limit expiry during the master method loop was mislabeled `master_failed`.** Wall exhaustion is now evaluated at the `lp is None` exit path itself, which also covers the boundary where the third and *final* method attempt consumes the remaining budget and then raises (no later loop iteration exists to notice; the first version of this fix missed that case — caught in review). Genuine all-method failures with budget remaining keep `master_failed`. Not reachable by the recovery jobs (no `--wall-limit-s`), but the code path is shared with wall-limited campaigns.
2. **`src/submit_legacy_bigtariff_recovery.sub` — lock fd opened with O_TRUNC** erased the current owner's diagnostic record before a duplicate job lost the `flock` race. Now `exec 9>>`.
3. **`src/submit_legacy_bigtariff_recovery.sub` — conda fallback stopped on the first *activatable* environment.** An activatable Python 3.10 `evsp_env` would have fataled the job without ever trying `evsp_env312`. The 3.12 check now runs inside the loop; non-3.12 candidates are skipped. (The sibling campaign `.sub` files share the old pattern; out of scope here.)

## Tests

- `tests/test_exact_pricer_resume.py`: fake-clock wall-limit labeling tests, including the requested boundary regression (`wall_limit_s=200`, three 60 s failing attempts — fails against both `f85798c` and the first flag-based fix) and a `master_failed` preservation test.
- `tests/test_legacy_recovery_scripts.py` (new; the launcher and `.sub` previously had zero coverage): bash parseability, requeue/open-mode/time-limit flags, append-mode locking, legacy identity-checked parameters, WAIT-grep classification against the real `MigrationError` messages, task→cell mapping against the original 867334 array arithmetic, dual commit pinning, and two conda-fallback tests that execute the script's actual selection block under mocked `conda`/`python` (both fail against the previous loop).
- Full suite: **216 passed, 28 subtests passed** (baseline at `f85798c`: 204 passed, 23 subtests). Python 3.12.3, pinned `requirements-unicorn.txt` versions.
- Additional local verification (documented in the report): end-to-end migration CLI checks on synthetic fixtures incl. preemption-mid-append idempotency, single-node cross-process flock checks incl. SIGKILL of the holder, a live SIGKILL/resume run on `Practice_Custom_TwoDuty_13301_13302.csv`, and `shellcheck -S warning` clean on both recovery scripts.

## Constraints respected

- No changes to routing, charging, tariff, battery, or objective assumptions: `f85798c` vs its direct parent touches only recovery/durability files, and the expanded-network pricing model is byte-identical from `f4e31c3` through `f85798c` (other model-adjacent code did change earlier in that range — `rerealize_routes.py`, `master_lp_scipy.py`, MIP-side runners — detailed in the report).
- No weakening of hash, trip-set, model-parameter, or Git-commit checks; fail-closed behavior unchanged. No solver switch; HiGHS remains the CG master. Legacy artifacts untouched; no generated results or datasets committed.
- Actual Unicorn recovery is **not** claimed. Explicitly unverified and reserved for the cluster: cross-node flock semantics on the shared filesystem, the real damaged task-22/24/32 tails under Python 3.12, witness availability, and cluster filesystem durability semantics.

## Review notes

Read `AUDIT_RECOVERY_20260811.md` first — sections: (1) confirmed correctness with its evidence basis, (2) bugs fixed here, (3) operational risks needing Unicorn verification, (4) optional non-blocking suggestions (incl. known dead code left untouched on purpose), (5) exact tests run and results. Correction-pass commit: `bab7bfed1d27575a47bf246ab25e2aa85a356834`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3ee1a9c-f087-4fc3-9394-08eadc412969?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3ee1a9c-f087-4fc3-9394-08eadc412969&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

